### PR TITLE
Synchronize CMakeLists.txt with msdfgen changes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(msdf-atlas-gen VERSION 1.2 LANGUAGES CXX)
 option(MSDF_ATLAS_GEN_BUILD_STANDALONE "Build the msdf-atlas-gen standalone executable" ON)
-set(MSDFGEN_BUILD_MSDFGEN_STANDALONE OFF CACHE BOOL "Build the msdfgen standalone executable")
+set(MSDFGEN_BUILD_STANDALONE OFF CACHE BOOL "Build the msdfgen standalone executable")
 set(MSDFGEN_USE_OPENMP OFF CACHE INTERNAL "Build with OpenMP support for multithreaded code (disabled for atlas gen)" FORCE)
 set(MSDFGEN_USE_CPP11 ON CACHE INTERNAL "Build with C++11 enabled (always enabled for atlas gen)" FORCE)
 set(MSDFGEN_INSTALL OFF CACHE BOOL "Generate installation target for msdfgen")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ if (MSVC)
     target_compile_definitions(msdf-atlas-gen PUBLIC _CRT_SECURE_NO_WARNINGS)
 endif()
 target_compile_features(msdf-atlas-gen PUBLIC cxx_std_11)
-target_link_libraries(msdf-atlas-gen PUBLIC Threads::Threads msdfgen::msdfgen msdfgen::msdfgen-ext)
+target_link_libraries(msdf-atlas-gen PUBLIC Threads::Threads msdfgen::msdfgen-core msdfgen::msdfgen-ext)
 
 # TODO make these public in msdfgen so that this doesn't have to be repeated here
 if(FREETYPE_WITH_PNG)


### PR DESCRIPTION
Thanks for the great library! This just brings the CMakeLists.txt up-to-date with the msdfgen submodule. Otherwise, building fails, e.g. 

```
$ cmake -S . -B build
...
-- Configuring done
CMake Error at CMakeLists.txt:55 (add_executable):
  Target "msdf-atlas-gen-standalone" links to target "msdfgen::msdfgen" but
  the target was not found.  Perhaps a find_package() call is missing for an
  IMPORTED target, or an ALIAS target is missing?
...
```