### PR TITLE
Add `-padding` argument

### DIFF
--- a/msdf-atlas-gen/TightAtlasPacker.h
+++ b/msdf-atlas-gen/TightAtlasPacker.h
@@ -32,7 +32,9 @@ public:
     void unsetDimensions();
     /// Sets the constraint to be used when determining dimensions
     void setDimensionsConstraint(DimensionsConstraint dimensionsConstraint);
-    /// Sets the padding between glyph boxes
+    /// Sets the size offset applied to glyph boxes before packing
+    void setSizeOffset(int sizeOffset);
+    /// Sets the padding between glyph boxes and the edge of the atlas
     void setPadding(int padding);
     /// Sets fixed glyph scale
     void setScale(double scale);
@@ -54,6 +56,7 @@ public:
 
 private:
     int width, height;
+    int sizeOffset;
     int padding;
     DimensionsConstraint dimensionsConstraint;
     double scale;
@@ -63,8 +66,8 @@ private:
     double miterLimit;
     double scaleMaximizationTolerance;
 
-    static int tryPack(GlyphGeometry *glyphs, int count, DimensionsConstraint dimensionsConstraint, int &width, int &height, int padding, double scale, double range, double miterLimit);
-    static double packAndScale(GlyphGeometry *glyphs, int count, int width, int height, int padding, double unitRange, double pxRange, double miterLimit, double tolerance);
+    static int tryPack(GlyphGeometry *glyphs, int count, DimensionsConstraint dimensionsConstraint, int &width, int &height, int sizeOffset, int padding, double scale, double range, double miterLimit);
+    static double packAndScale(GlyphGeometry *glyphs, int count, int width, int height, int sizeOffset, int padding, double unitRange, double pxRange, double miterLimit, double tolerance);
 
 };
 

--- a/msdf-atlas-gen/main.cpp
+++ b/msdf-atlas-gen/main.cpp
@@ -85,6 +85,8 @@ ATLAS CONFIGURATION
       power of two square / ... rectangle / any square / square with side divisible by 2 / ... 4
   -yorigin <bottom / top>
       Determines whether the Y-axis is oriented upwards (bottom origin, default) or downwards (top origin).
+  -padding <amount>
+      Specifies the amount of padding applied to each side of glyphs in pixels
 
 OUTPUT SPECIFICATION - one or more can be specified
   -imageout <filename.*>
@@ -245,6 +247,7 @@ struct Configuration {
     ImageType imageType;
     ImageFormat imageFormat;
     YDirection yDirection;
+    int padding;
     int width, height;
     double emSize;
     double pxRange;
@@ -524,6 +527,14 @@ int main(int argc, const char * const *argv) {
                 config.yDirection = YDirection::TOP_DOWN;
             else
                 ABORT("Invalid Y-axis origin. Use bottom or top.");
+            ++argPos;
+            continue;
+        }
+        ARG_CASE("-padding", 1) {
+            unsigned padding;
+            if (!parseUnsigned(padding, argv[++argPos]) || (int) padding < 0)
+                ABORT("Invalid padding argument. Use -padding <N> with N being a non-negative integer.");
+            config.padding = (int) padding;
             ++argPos;
             continue;
         }
@@ -957,8 +968,9 @@ int main(int argc, const char * const *argv) {
             atlasPacker.setDimensions(fixedWidth, fixedHeight);
         else
             atlasPacker.setDimensionsConstraint(atlasSizeConstraint);
-        atlasPacker.setPadding(config.imageType == ImageType::MSDF || config.imageType == ImageType::MTSDF ? 0 : -1);
-        // TODO: In this case (if padding is -1), the border pixels of each glyph are black, but still computed. For floating-point output, this may play a role.
+        atlasPacker.setPadding(config.padding);
+        atlasPacker.setSizeOffset(config.imageType == ImageType::MSDF || config.imageType == ImageType::MTSDF ? 0 : -1);
+        // TODO: In this case (if the glyph size offset is -1), the border pixels of each glyph are black, but still computed. For floating-point output, this may play a role.
         if (fixedScale)
             atlasPacker.setScale(config.emSize);
         else

--- a/msdf-atlas-gen/rectangle-packing.h
+++ b/msdf-atlas-gen/rectangle-packing.h
@@ -8,11 +8,11 @@ namespace msdf_atlas {
 
 /// Packs the rectangle array into an atlas with fixed dimensions, returns how many didn't fit (0 on success)
 template <typename RectangleType>
-int packRectangles(RectangleType *rectangles, int count, int width, int height, int padding = 0);
+int packRectangles(RectangleType *rectangles, int count, int width, int height, int sizeOffset = 0, int padding = 0);
 
 /// Packs the rectangle array into an atlas of unknown size, returns the minimum required dimensions constrained by SizeSelector
 template <class SizeSelector, typename RectangleType>
-std::pair<int, int> packRectangles(RectangleType *rectangles, int count, int padding = 0);
+std::pair<int, int> packRectangles(RectangleType *rectangles, int count, int sizeOffset = 0, int padding = 0);
 
 }
 

--- a/msdf-atlas-gen/rectangle-packing.hpp
+++ b/msdf-atlas-gen/rectangle-packing.hpp
@@ -7,13 +7,13 @@
 namespace msdf_atlas {
 
 static void copyRectanglePlacement(Rectangle &dst, const Rectangle &src, int offset) {
-    dst.x = src.x + offset;
-    dst.y = src.y + offset;
+    dst.x = src.x+offset;
+    dst.y = src.y+offset;
 }
 
 static void copyRectanglePlacement(OrientedRectangle &dst, const OrientedRectangle &src, int offset) {
-    dst.x = src.x + offset;
-    dst.y = src.y + offset;
+    dst.x = src.x+offset;
+    dst.y = src.y+offset;
     dst.rotated = src.rotated;
 }
 
@@ -21,16 +21,16 @@ template <typename RectangleType>
 int packRectangles(RectangleType *rectangles, int count, int width, int height, int sizeOffset, int padding) {
     if (sizeOffset || padding)
         for (int i = 0; i < count; ++i) {
-            rectangles[i].w += sizeOffset + padding;
-            rectangles[i].h += sizeOffset + padding;
+            rectangles[i].w += sizeOffset+padding;
+            rectangles[i].h += sizeOffset+padding;
         }
-    int result = RectanglePacker(width+sizeOffset-padding*2, height+sizeOffset-padding*2).pack(rectangles, count);
+    int result = RectanglePacker(width+sizeOffset-padding, height+sizeOffset-padding).pack(rectangles, count);
     if (sizeOffset || padding)
         for (int i = 0; i < count; ++i) {
             rectangles[i].x += padding;
             rectangles[i].y += padding;
-            rectangles[i].w -= sizeOffset + padding;
-            rectangles[i].h -= sizeOffset + padding;
+            rectangles[i].w -= sizeOffset+padding;
+            rectangles[i].h -= sizeOffset+padding;
         }
     return result;
 }
@@ -48,7 +48,7 @@ std::pair<int, int> packRectangles(RectangleType *rectangles, int count, int siz
     SizeSelector sizeSelector(totalArea);
     int width, height;
     while (sizeSelector(width, height)) {
-        if (!RectanglePacker(width+sizeOffset-padding*2, height+sizeOffset-padding*2).pack(rectanglesCopy.data(), count)) {
+        if (!RectanglePacker(width+sizeOffset-padding, height+sizeOffset-padding).pack(rectanglesCopy.data(), count)) {
             dimensions.first = width;
             dimensions.second = height;
             for (int i = 0; i < count; ++i)

--- a/msdf-atlas-gen/rectangle-packing.hpp
+++ b/msdf-atlas-gen/rectangle-packing.hpp
@@ -6,51 +6,53 @@
 
 namespace msdf_atlas {
 
-static void copyRectanglePlacement(Rectangle &dst, const Rectangle &src) {
-    dst.x = src.x;
-    dst.y = src.y;
+static void copyRectanglePlacement(Rectangle &dst, const Rectangle &src, int offset) {
+    dst.x = src.x + offset;
+    dst.y = src.y + offset;
 }
 
-static void copyRectanglePlacement(OrientedRectangle &dst, const OrientedRectangle &src) {
-    dst.x = src.x;
-    dst.y = src.y;
+static void copyRectanglePlacement(OrientedRectangle &dst, const OrientedRectangle &src, int offset) {
+    dst.x = src.x + offset;
+    dst.y = src.y + offset;
     dst.rotated = src.rotated;
 }
 
 template <typename RectangleType>
-int packRectangles(RectangleType *rectangles, int count, int width, int height, int padding) {
-    if (padding)
+int packRectangles(RectangleType *rectangles, int count, int width, int height, int sizeOffset, int padding) {
+    if (sizeOffset || padding)
         for (int i = 0; i < count; ++i) {
-            rectangles[i].w += padding;
-            rectangles[i].h += padding;
+            rectangles[i].w += sizeOffset + padding;
+            rectangles[i].h += sizeOffset + padding;
         }
-    int result = RectanglePacker(width+padding, height+padding).pack(rectangles, count);
-    if (padding)
+    int result = RectanglePacker(width+sizeOffset-padding*2, height+sizeOffset-padding*2).pack(rectangles, count);
+    if (sizeOffset || padding)
         for (int i = 0; i < count; ++i) {
-            rectangles[i].w -= padding;
-            rectangles[i].h -= padding;
+            rectangles[i].x += padding;
+            rectangles[i].y += padding;
+            rectangles[i].w -= sizeOffset + padding;
+            rectangles[i].h -= sizeOffset + padding;
         }
     return result;
 }
 
 template <class SizeSelector, typename RectangleType>
-std::pair<int, int> packRectangles(RectangleType *rectangles, int count, int padding) {
+std::pair<int, int> packRectangles(RectangleType *rectangles, int count, int sizeOffset, int padding) {
     std::vector<RectangleType> rectanglesCopy(count);
     int totalArea = 0;
     for (int i = 0; i < count; ++i) {
-        rectanglesCopy[i].w = rectangles[i].w+padding;
-        rectanglesCopy[i].h = rectangles[i].h+padding;
+        rectanglesCopy[i].w = rectangles[i].w+sizeOffset+padding;
+        rectanglesCopy[i].h = rectangles[i].h+sizeOffset+padding;
         totalArea += rectangles[i].w*rectangles[i].h;
     }
     std::pair<int, int> dimensions;
     SizeSelector sizeSelector(totalArea);
     int width, height;
     while (sizeSelector(width, height)) {
-        if (!RectanglePacker(width+padding, height+padding).pack(rectanglesCopy.data(), count)) {
+        if (!RectanglePacker(width+sizeOffset-padding*2, height+sizeOffset-padding*2).pack(rectanglesCopy.data(), count)) {
             dimensions.first = width;
             dimensions.second = height;
             for (int i = 0; i < count; ++i)
-                copyRectanglePlacement(rectangles[i], rectanglesCopy[i]);
+                copyRectanglePlacement(rectangles[i], rectanglesCopy[i], padding);
             --sizeSelector;
         } else
             ++sizeSelector;


### PR DESCRIPTION
Arranges glyphs such that there are a # of empty pixels equal to value specified in the `-padding` argument on all sides.

`-pxrange 5`
![image](https://github.com/Chlumsky/msdf-atlas-gen/assets/24485393/49f96665-2972-4b41-b695-679d5272ca52)

`-pxrange 5 -padding 5`
![image](https://github.com/Chlumsky/msdf-atlas-gen/assets/24485393/e6f0fc96-b944-492b-8425-a17a3fc83526)
