### PR TITLE
Update example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ bool generateAtlas(const char *fontFilename) {
             ImmediateAtlasGenerator<
                 float, // pixel type of buffer for individual glyphs depends on generator function
                 3, // number of atlas color channels
-                &msdfGenerator, // function to generate bitmaps for individual glyphs
+                msdfGenerator, // function to generate bitmaps for individual glyphs
                 BitmapAtlasStorage<byte, 3> // class that stores the atlas bitmap
                 // For example, a custom atlas storage class that stores it in VRAM can be used.
             > generator(width, height);


### PR DESCRIPTION
Using the old example code as-is produces a compiler error `'&' requires l-value` in MSVC (same as #54) since MSVC doesn't allow using ampersands to functions (at least, in this case). I updated the example code to account for this.