### PR TITLE
Fix annoying DynamicAtlas.hpp inline warning

### DIFF
--- a/msdf-atlas-gen/DynamicAtlas.hpp
+++ b/msdf-atlas-gen/DynamicAtlas.hpp
@@ -3,7 +3,7 @@
 
 namespace msdf_atlas {
 
-static int ceilPOT(int x) {
+static inline int ceilPOT(int x) {
     if (x > 0) {
         int y = 1;
         while (y < x)


### PR DESCRIPTION
Hello

When compiling with the latest version of clang (19.1.7 on arch linux), the following you give you a warning:
```cpp
//DynamicAtlas.hpp
static int ceilPOT(int x) {
    if (x > 0) {
        int y = 1;
        while (y < x)
            y <<= 1;
        return y;
    }
    return 0;
}
```
Every time someone compiles, it will give a very annoying warning similar to this :
```
[14/27] Building CXX object CMakeFiles/Pain.dir/Pain/src/CoreRender/Texture.cpp.o
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/src/CoreRender/Texture.cpp:5:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Renderer/Renderer2d.h:6:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Text/Font.h:4:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/msdf-atlas-gen.h:33:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.h:52:
/home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.hpp:6:12: warning: 'static' function 'ceilPOT' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration]
    6 | static int ceilPOT(int x) {
      |            ^~~~~~~
1 warning generated.
[15/27] Building CXX object CMakeFiles/Pain.dir/Pain/src/CoreRender/Renderer/Draw2d.cpp.o
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/src/CoreRender/Renderer/Draw2d.cpp:1:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Renderer/Renderer2d.h:6:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Text/Font.h:4:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/msdf-atlas-gen.h:33:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.h:52:
/home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.hpp:6:12: warning: 'static' function 'ceilPOT' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration]
    6 | static int ceilPOT(int x) {
      |            ^~~~~~~
1 warning generated.
[16/27] Building CXX object CMakeFiles/Pain.dir/Pain/src/CoreFiles/Application.cpp.o
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/src/CoreFiles/Application.cpp:5:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Renderer/Renderer2d.h:6:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Text/Font.h:4:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/msdf-atlas-gen.h:33:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.h:52:
/home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.hpp:6:12: warning: 'static' function 'ceilPOT' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration]
    6 | static int ceilPOT(int x) {
      |            ^~~~~~~
1 warning generated.
[17/27] Building CXX object CMakeFiles/Pain.dir/Pain/src/CoreRender/Renderer/Renderer2d.cpp.o
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/src/CoreRender/Renderer/Renderer2d.cpp:1:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Renderer/Renderer2d.h:6:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Text/Font.h:4:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/msdf-atlas-gen.h:33:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.h:52:
/home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.hpp:6:12: warning: 'static' function 'ceilPOT' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration]
    6 | static int ceilPOT(int x) {
      |            ^~~~~~~
1 warning generated.
[18/27] Building CXX object CMakeFiles/Pain.dir/Pain/src/CoreRender/Text/Font.cpp.o
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/src/CoreRender/Text/Font.cpp:1:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Text/Font.h:4:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/msdf-atlas-gen.h:33:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.h:52:
/home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.hpp:6:12: warning: 'static' function 'ceilPOT' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration]
    6 | static int ceilPOT(int x) {
      |            ^~~~~~~
1 warning generated.
[20/27] Building CXX object CMakeFiles/Pain.dir/Pain/src/Misc/BasicOrthoCamera.cpp.o
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/src/Misc/BasicOrthoCamera.cpp:3:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Renderer/Renderer2d.h:6:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Text/Font.h:4:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/msdf-atlas-gen.h:33:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.h:52:
/home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.hpp:6:12: warning: 'static' function 'ceilPOT' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration]
    6 | static int ceilPOT(int x) {
      |            ^~~~~~~
1 warning generated.
[21/27] Building CXX object CMakeFiles/Pain.dir/Pain/src/ECS/Scene.cpp.o
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/src/ECS/Scene.cpp:2:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Renderer/Renderer2d.h:6:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Text/Font.h:4:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/msdf-atlas-gen.h:33:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.h:52:
/home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.hpp:6:12: warning: 'static' function 'ceilPOT' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration]
    6 | static int ceilPOT(int x) {
      |            ^~~~~~~
1 warning generated.
[22/27] Building CXX object CMakeFiles/Pain.dir/Pain/src/pain.cpp.o
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/src/pain.cpp:1:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/pain.h:18:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Renderer/Renderer2d.h:6:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Text/Font.h:4:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/msdf-atlas-gen.h:33:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.h:52:
/home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.hpp:6:12: warning: 'static' function 'ceilPOT' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration]
    6 | static int ceilPOT(int x) {
      |            ^~~~~~~
1 warning generated.
[24/27] Building CXX object Example/scriptGame/CMakeFiles/scriptGame.dir/src/dummy.cpp.o
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Example/scriptGame/src/dummy.cpp:2:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/pain.h:18:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Renderer/Renderer2d.h:6:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/include/CoreRender/Text/Font.h:4:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/msdf-atlas-gen.h:33:
In file included from /home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.h:52:
/home/jaoschmidt/Documents/jogo/Pain-Engine/Pain/external/msdf-atlas-gen/msdf-atlas-gen/DynamicAtlas.hpp:6:12: warning: 'static' function 'ceilPOT' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration]
    6 | static int ceilPOT(int x) {
      |            ^~~~~~~
```

This should fix it