### PR TITLE
Inverting the y-axis

### DIFF
--- a/msdf-atlas-gen/GlyphGeometry.cpp
+++ b/msdf-atlas-gen/GlyphGeometry.cpp
@@ -213,6 +213,10 @@ const msdfgen::Shape &GlyphGeometry::getShape() const {
     return shape;
 }
 
+void GlyphGeometry::setInverseYAxis(bool inverse) {
+    shape.inverseYAxis = inverse;
+}
+
 const msdfgen::Shape::Bounds &GlyphGeometry::getShapeBounds() const {
     return bounds;
 }

--- a/msdf-atlas-gen/GlyphGeometry.h
+++ b/msdf-atlas-gen/GlyphGeometry.h
@@ -52,6 +52,8 @@ public:
     double getGeometryScale() const;
     /// Returns the glyph's shape
     const msdfgen::Shape &getShape() const;
+    /// Sets the glyph's flag for inverting the y-axis
+    void setInverseYAxis(bool inverse);
     /// Returns the glyph's shape's raw bounds
     const msdfgen::Shape::Bounds &getShapeBounds() const;
     /// Returns the glyph's advance


### PR DESCRIPTION
This PR introduces a small function to easily control the inversion of the y-Axis in the glyph shape. In some rendering APIs like Vulkan, the y-axis points downwards, so it is much more convenient to invert the y-axis of the glyph shapes.

Example:
```C++
for (auto& glyph : m_Data->Glyphs) {
    glyph.setInverseYAxis(true);
    glyph.edgeColoring(&msdfgen::edgeColoringInkTrap, DEFAULT_ANGLE_THRESHOLD, 0);
}
```