### PR TITLE
explicitly specifying cast for conversion 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,14 @@
 *.suo
 *.VC.opendb
 *.VC.db
+*.log
+*.a
+*.cmake
+CMakeCache.txt
+Makefile
+compile_commands.json
+CMakeFiles
+vcpkg_installed
 /bin/*.lib
 /bin/msdf-atlas-gen
 output.png

--- a/msdf-atlas-gen/main.cpp
+++ b/msdf-atlas-gen/main.cpp
@@ -335,7 +335,8 @@ static bool makeAtlas(const std::vector<GlyphGeometry> &glyphs, const std::vecto
     generator.setAttributes(config.generatorAttributes);
     generator.setThreadCount(config.threadCount);
     generator.generate(glyphs.data(), glyphs.size());
-    msdfgen::BitmapConstSection<T, N> bitmap = (msdfgen::BitmapConstSection<T, N>) generator.atlasStorage();
+    msdfgen::BitmapConstRef<T, N> bitmapRef = static_cast<msdfgen::BitmapConstRef<T, N>>(generator.atlasStorage());
+    msdfgen::BitmapConstSection<T, N> bitmap(bitmapRef);
     bitmap.reorient(config.yDirection);
 
     bool success = true;


### PR DESCRIPTION
Hi 
In a clang on macOS there's an [issue](https://github.com/Chlumsky/msdf-atlas-gen/issues/144) with building this awesome tool 
My clang version used for compiling is (`clang -v`):
```
Apple clang version 14.0.0 (clang-1400.0.29.202)
Target: x86_64-apple-darwin22.6.0
Thread model: posix
```
Issue root is that compiler sees an ambiguosity in the following cast:
```c++
msdfgen::BitmapConstSection<T, N> bitmap = (msdfgen::BitmapConstSection<T, N>) generator.atlasStorage();
```
It sees several constructors for `msdfgen::BitmapConstSection` 
So my suggestion is to explicitly tell the compiler which cast it must use here, therefore fixing abovementioned issue 