### PR TITLE
Add pragma once to hpp files

### DIFF
--- a/msdf-atlas-gen/BitmapAtlasStorage.hpp
+++ b/msdf-atlas-gen/BitmapAtlasStorage.hpp
@@ -1,4 +1,6 @@
 
+#pragma once
+
 #include "BitmapAtlasStorage.h"
 
 #include <cstring>

--- a/msdf-atlas-gen/DynamicAtlas.hpp
+++ b/msdf-atlas-gen/DynamicAtlas.hpp
@@ -1,4 +1,6 @@
 
+#pragma once
+
 #include "DynamicAtlas.h"
 
 #include "utils.hpp"

--- a/msdf-atlas-gen/ImmediateAtlasGenerator.hpp
+++ b/msdf-atlas-gen/ImmediateAtlasGenerator.hpp
@@ -1,4 +1,6 @@
 
+#pragma once
+
 #include "ImmediateAtlasGenerator.h"
 
 #include <algorithm>

--- a/msdf-atlas-gen/image-save.hpp
+++ b/msdf-atlas-gen/image-save.hpp
@@ -1,4 +1,6 @@
 
+#pragma once
+
 #include "image-save.h"
 
 #include <cstdio>

--- a/msdf-atlas-gen/rectangle-packing.hpp
+++ b/msdf-atlas-gen/rectangle-packing.hpp
@@ -1,4 +1,6 @@
 
+#pragma once
+
 #include "rectangle-packing.h"
 
 #include <vector>


### PR DESCRIPTION
When only including the .h **OR** the .hpp, MSVC warns about transitive includes on the other:

<img width="1111" height="499" alt="image" src="https://github.com/user-attachments/assets/0a08182d-177d-492c-87df-91885bc35182" />

When including **both** in the same cpp file, multiple definition error due to lack of header guard in hpp files.

This PR adds pragma once to all the hpp files that are missing it